### PR TITLE
Fixes add snippet link.

### DIFF
--- a/src/Generator.hx
+++ b/src/Generator.hx
@@ -226,7 +226,7 @@ class Generator {
   }
   
   public inline function getAddLinkUrl(category:Category  = null, page:Page = null) {
-    var fileNameHint = "/?filename=snippet-name.md";
+    var fileNameHint = "/snippet-name.md/?filename=snippet-name.md";
     var directory = if (category != null) {
       getDirectory(category.pages[0].contentPath);
     } else {


### PR DESCRIPTION
For some reason it was pointing to `assets/content/cookbook/` and not to `assets/content/cookbook/<category>` 