### PR TITLE
Added abstract type: Precision Float

### DIFF
--- a/assets/content/cookbook/Abstract types/Precision Float
+++ b/assets/content/cookbook/Abstract types/Precision Float
@@ -1,0 +1,47 @@
+[tags]: / "abstract-type,math"
+
+# Precision Float 
+
+This [abstract type](http://haxe.org/manual/types-abstract.html) is based on the underlying `Float` type, but
+whenever it is converted back to an actual `Float` it is rounded to avoid the famous [rounding errors](https://en.wikipedia.org/wiki/Round-off_error)
+occuring in floating point aritmetics.
+
+**Please note** that this example doesn't solve the rounding error problem - it just covers it by rounding the error away.
+This shouldn't be used in situations where accumulated errors might cause critical problems - for example in financial calculations.
+For those cases, something like Franco Ponticelli's [thx.Decimal](https://github.com/fponticelli/thx.core/blob/master/src/thx/Decimal.hx) should be used instead.
+
+```haxe
+abstract PFloat(Float) from Float {
+  inline function new(value : Float)  
+    this = value;
+  
+  // The following rounds the result whenever converted to a Float
+  @:to inline public function toFloat():Float 
+    return roundPrecision(this);
+   
+  @:to inline public function toString():String
+    return Std.string(toFloat());
+  
+  static inline var multiplier = 1000000000000000;
+    
+  static inline function roundPrecision(value:Float):Float
+    return Math.round(value * multiplier) / multiplier;
+}
+```
+
+## Usage
+
+```haxe
+// Standard float gives a result with rounding error
+var f:Float = 2.0 - 1.1;
+trace(f); // 0.8999999999999999
+
+// PFloat abstract rounds the error away
+var pf:PFloat = 2.0 - 1.1;
+trace(pf); // 0.9
+```
+
+> Learn about Haxe Abstracts here: <http://haxe.org/manual/types-abstract.html>
+> 
+> Author: [Jonas Nyström](https://github.com/cambiata)
+

--- a/assets/content/cookbook/Abstract types/Rounded Float
+++ b/assets/content/cookbook/Abstract types/Rounded Float
@@ -1,17 +1,17 @@
 [tags]: / "abstract-type,math"
 
-# Precision Float 
+# Rounded Float 
 
 This [abstract type](http://haxe.org/manual/types-abstract.html) is based on the underlying `Float` type, but
 whenever it is converted back to an actual `Float` it is rounded to avoid the famous [rounding errors](https://en.wikipedia.org/wiki/Round-off_error)
 occuring in floating point aritmetics.
 
-**Please note** that this example doesn't solve the rounding error problem - it just covers it by rounding the error away.
+**Please note** that this example doesn't solve the rounding error problem - it just covers it by rounding the errors away.
 This shouldn't be used in situations where accumulated errors might cause critical problems - for example in financial calculations.
 For those cases, something like Franco Ponticelli's [thx.Decimal](https://github.com/fponticelli/thx.core/blob/master/src/thx/Decimal.hx) should be used instead.
 
 ```haxe
-abstract PFloat(Float) from Float {
+abstract RFloat(Float) from Float {
   inline function new(value : Float)  
     this = value;
   
@@ -36,9 +36,9 @@ abstract PFloat(Float) from Float {
 var f:Float = 2.0 - 1.1;
 trace(f); // 0.8999999999999999
 
-// PFloat abstract rounds the error away
-var pf:PFloat = 2.0 - 1.1;
-trace(pf); // 0.9
+// RFloat abstract rounds the error away
+var rf:RFloat = 2.0 - 1.1;
+trace(rf); // 0.9
 ```
 
 > Learn about Haxe Abstracts here: <http://haxe.org/manual/types-abstract.html>


### PR DESCRIPTION
Hi!

Got the idea of an abstract to get rid of the tedious float rounding errors.
I'm not really sure about the name - "Precision Float" is a bit misleading, as it's based on standard Float, and doesn't have higher precision, it just covers the errors by rounding them away...
Please suggest a better name!

Also, I might have missed important stuff when it comes to this floating point aritmetic area... Please enlighten me about problems and dangers with the example code.
(As a start, I have added a disclaimer text about potential dangers...)

 