### PR TITLE
Fix compiled JavaScript target example

### DIFF
--- a/assets/content/cookbook/Beginner/declare-classes.md
+++ b/assets/content/cookbook/Beginner/declare-classes.md
@@ -118,7 +118,8 @@ class Point {
 }
 
 // Create a new Value Int instance
-var myPoint = new Point(5, 2);
+var myPoint = new Point(100, 150);
+trace(myPoint.x);
 ```
 In JavaScript, this will be compiled (where possible) as:
 ```js

--- a/assets/content/cookbook/Beginner/declare-classes.md
+++ b/assets/content/cookbook/Beginner/declare-classes.md
@@ -102,7 +102,7 @@ var myStringValue = new Value<String>("String");
 ```
 > See <http://haxe.org/manual/type-system-generic.html>
 
-### Declare a inline constructor 
+### Declare an inline constructor 
 
 Declare a new class with an inline constructor (`new()` function), create a new instance and reveal its effect.
 


### PR DESCRIPTION
Harmonize the Haxe and JavaScript values and add a missing `trace` to justify the `console.log`.