### PR TITLE
macro-function -> expression-macro

### DIFF
--- a/assets/content/cookbook/Macros/add-git-commit-hash-in-build.md
+++ b/assets/content/cookbook/Macros/add-git-commit-hash-in-build.md
@@ -1,4 +1,4 @@
-[tags]: / "git,macro-function,process"
+[tags]: / "git,expression-macro,process"
 
 # Add git commit-hash in build
 

--- a/assets/content/cookbook/Macros/add-parameters-as-fields.md
+++ b/assets/content/cookbook/Macros/add-parameters-as-fields.md
@@ -1,4 +1,4 @@
-[tags]: / "macro-function,building-fields"
+[tags]: / "expression-macro,building-fields"
 
 # Add parameters as fields
 

--- a/assets/content/cookbook/Macros/assert-with-values.md
+++ b/assets/content/cookbook/Macros/assert-with-values.md
@@ -1,4 +1,4 @@
-[tags]: / "macro-function,validation"
+[tags]: / "expression-macro,validation"
 
 # Assert macro that shows sub-expression values
 

--- a/assets/content/cookbook/Macros/combine-objects.md
+++ b/assets/content/cookbook/Macros/combine-objects.md
@@ -1,4 +1,4 @@
-[tags]: / "macro-function"
+[tags]: / "expression-macro"
 
 # Combine two or more structures
 

--- a/assets/content/cookbook/Macros/enum-abstract-values.md
+++ b/assets/content/cookbook/Macros/enum-abstract-values.md
@@ -1,4 +1,4 @@
-[tags]: / "enum,macro-function"
+[tags]: / "enum,expression-macro"
 
 # Get all values of an @:enum abstract
 

--- a/assets/content/cookbook/Macros/extract-enum-value.md
+++ b/assets/content/cookbook/Macros/extract-enum-value.md
@@ -1,4 +1,4 @@
-[tags]: / "enum,pattern-matching,macro-function"
+[tags]: / "enum,pattern-matching,expression-macro"
 
 # Extract values from known enum instances
 

--- a/assets/content/cookbook/Macros/generating-code-in-a-macro.md
+++ b/assets/content/cookbook/Macros/generating-code-in-a-macro.md
@@ -1,4 +1,4 @@
-[tags]: / "macro-function"
+[tags]: / "expression-macro"
 
 # Generating code in a macro
 

--- a/assets/content/cookbook/Macros/get-compiler-define-value.md
+++ b/assets/content/cookbook/Macros/get-compiler-define-value.md
@@ -1,4 +1,4 @@
-[tags]: / "conditional-compilation,macro-function"
+[tags]: / "conditional-compilation,expression-macro"
 
 # Working with compiler flags
 

--- a/assets/content/cookbook/Macros/validate-json.md
+++ b/assets/content/cookbook/Macros/validate-json.md
@@ -1,4 +1,4 @@
-[tags]: / "json,validation,macro-function"
+[tags]: / "json,validation,expression-macro"
 
 # Validates a .JSON file compile-time
 


### PR DESCRIPTION
"Macro function" is a misleading term, since initialization and build macros are implemented as "functions" too. Besides, "expression macro" is the more official term and used in the Haxe manual.