### PR TITLE
Fixed type in File System example

### DIFF
--- a/assets/content/cookbook/Beginner/using-filesystem.md
+++ b/assets/content/cookbook/Beginner/using-filesystem.md
@@ -39,7 +39,7 @@ Otherwise you will get the error:
 This example reads a text file:
 ```haxe
 var content:String = sys.io.File.getContent('my_folder/my_file.txt');
-trace(myContent);
+trace(content);
 ```
 
 ### Write content to a file


### PR DESCRIPTION
There was a type in the variable name used in the example of reading the
contents of a file. It should be "content" but it was actually "myContent"
which made the example not work.