### PR TITLE
Update: Loading a file from web - Replace "api" with "api6" in the used URI

### DIFF
--- a/assets/content/cookbook/Beginner/loading-external-files.md
+++ b/assets/content/cookbook/Beginner/loading-external-files.md
@@ -8,7 +8,7 @@ The following example loads your IP-address using a free-to-use web API. The ser
 This string is parsed to an object `result` using the `haxe.Json.parse` function. After this, we trace the IP-address `result.ip`.
 
 ```haxe
-var http = new haxe.Http("https://api.ipify.org?format=json");
+var http = new haxe.Http("https://api6.ipify.org?format=json");
 
 http.onData = function (data:String) {
   var result = haxe.Json.parse(data);


### PR DESCRIPTION
Replace "api" with "api6" in the used URI

Sources:
* https://code.haxe.org/category/beginner/loading-external-files.html