### PR TITLE
Remove redundancies from "Working with compiler flags."

### DIFF
--- a/assets/content/cookbook/Macros/get-compiler-define-value.md
+++ b/assets/content/cookbook/Macros/get-compiler-define-value.md
@@ -12,34 +12,28 @@ It is possible to get and set compiler flags, check if they are defined, and lis
 
 ## Implementation
 ```haxe
+import haxe.macro.Compiler;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
 class Main {
   static function main() {
-    trace("Warning: " + getDefine("warning"));
-    if (!isDefined("foo")) {
-      setDefine("foo", "bar");
-    }
+    trace("Warning: " + Compiler.getDefine("warning"));
+    #if !foo
+    setDefine("foo", "bar");
+    #end
     trace(getDefines());
   }
 
-  // Shorthand for retrieving compiler flag values.
-  static macro function getDefine(key : String) : haxe.macro.Expr {
-    return macro $v{haxe.macro.Context.definedValue(key)};
-  }
-
-  // Shorthand for setting compiler flags.
-  static macro function setDefine(key : String, value : String) : haxe.macro.Expr {
-    haxe.macro.Compiler.define(key, value);
+  // Shorthand for setting compiler flags from non-macro code.
+  static macro function setDefine(key : String, value : String) : Expr {
+    Compiler.define(key, value);
     return macro null;
   }
 
-  // Shorthand for checking if a compiler flag is defined.
-  static macro function isDefined(key : String) : haxe.macro.Expr {
-    return macro $v{haxe.macro.Context.defined(key)};
-  }
-
   // Shorthand for retrieving a map of all defined compiler flags.
-  static macro function getDefines() : haxe.macro.Expr {
-    var defines : Map<String, String> = haxe.macro.Context.getDefines();
+  static macro function getDefines() : Expr {
+    var defines : Map<String, String> = Context.getDefines();
     // Construct map syntax so we can return it as an expression
     var map : Array<haxe.macro.Expr> = [];
     for (key in defines.keys()) {
@@ -72,5 +66,7 @@ The last line may differ depending on the Haxe version and compilation options, 
 > Learn about conditional compilation here: <https://haxe.org/manual/lf-condition-compilation.html>
 >
 > Learn about available global compiler flags here: <https://haxe.org/manual/compiler-usage-flags.html>
+> 
+> Learn about macro classes here: <https://api.haxe.org/haxe/macro/index.html>
 >
 > Author: [Domagoj Štrekelj](https://github.com/dstrekelj)


### PR DESCRIPTION
This sample re-implemented `haxe.macro.Compiler.getDefine()`, giving the impression that you must re-implement it. It's much better to encourage people to use standard library functionality.

The sample also re-implemented conditional compilation, and its implementation had an error. It would always call `setDefine("foo", "bar")` regardless of the result of `isDefined()`. By using conditional compilation instead, we can avoid accidentally overwriting `foo`.